### PR TITLE
chore: expose modelers from root

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,3 @@
+export { default as BaseModeler } from './base/Modeler';
+export { default as CamundaPlatformModeler } from './camunda-platform/Modeler';
+export { default as CamundaCloudModeler } from './camunda-cloud/Modeler';

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "camunda-dmn-js",
   "version": "0.1.0",
   "description": "Embeddable Camunda modeling distributions based on dmn-js",
-  "main": "lib/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
   "files": [
-    "lib",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
`lib` is no longer exposed but the modelers
can be imported from the root of the package:

```javascript
import { BaseModeler as Modeler } from 'camunda-dmn-js';

const modeler = new Modeler();
```

Closes #7