### PR TITLE
feat: temporarily disable overview

### DIFF
--- a/lib/base/Modeler.js
+++ b/lib/base/Modeler.js
@@ -19,24 +19,17 @@ import {
   DmnPropertiesProviderModule
 } from 'dmn-js-properties-panel';
 
-import { createOverviewModule } from './features/overview/Overview';
-
 export default class CamundaDmnModeler extends DmnModeler {
 
   constructor(options = {}) {
 
     const {
       common = {},
-      moddleExtensions = {},
       drd = {},
-      decisionTable = {},
-      literalExpression = {},
       ...otherOptions
     } = options;
 
     const disableAdjustOrigin = drd.disableAdjustOrigin || common.disableAdjustOrigin;
-
-    const overviewModule = createOverviewModule();
 
     super({
       ...otherOptions,
@@ -45,14 +38,7 @@ export default class CamundaDmnModeler extends DmnModeler {
         disableAdjustOrigin ? diagramOriginModule : alignToOriginModule,
         DmnPropertiesPanelModule,
         DmnPropertiesProviderModule
-      ]),
-      decisionTable: mergeModules(decisionTable, [
-        overviewModule
-      ]),
-      literalExpression: mergeModules(literalExpression, [
-        overviewModule
-      ]),
-      moddleExtensions
+      ])
     });
   }
 }

--- a/test/base/features/overview/OverviewSpec.js
+++ b/test/base/features/overview/OverviewSpec.js
@@ -11,7 +11,8 @@ import {
 import { waitFor } from '@testing-library/dom';
 
 
-describe('Overview', function() {
+// TODO(barmac): re-enable when overview is done
+describe.skip('Overview', function() {
 
   let container;
 


### PR DESCRIPTION
This disables overview as it clashes with existing implementations even if not used. Let's make sure it works correctly and is usable in at least one tool before we re-expose it.