### PR TITLE
fix: provide BKM and Input Data name in suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [camunda-dmn-js](https://github.com/camunda/camunda-dmn-j
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: provide BKM and Input Data name in variable suggestions ([#117](https://github.com/camunda/camunda-dmn-js/issues/117))
 
 ## 2.7.0
 

--- a/lib/base/features/variable-provider/CamundaVariableProvider.js
+++ b/lib/base/features/variable-provider/CamundaVariableProvider.js
@@ -23,7 +23,7 @@ CamundaVariableProvider.$inject = [ 'variableResolver' ];
 function getVariableName(variable) {
   const { origin } = variable;
 
-  if (origin && is(origin, 'dmn:DRGElement')) {
+  if (origin && is(origin, 'dmn:Decision')) {
     return origin.get('id');
   }
 

--- a/test/base/features/variable-provider/CamundaVariableProviderSpec.js
+++ b/test/base/features/variable-provider/CamundaVariableProviderSpec.js
@@ -10,7 +10,21 @@ describe('CamundaVariableProvider', function() {
     beforeEach(bootstrapBaseModeler(diagramXML));
 
 
-    it('should provide input data id as name', inject(function(variableResolver, elementRegistry) {
+    it('should provide decision as ID', inject(function(variableResolver, _parent) {
+
+      // given
+      const requiringDecision = _parent.getDefinitions().get('drgElement').find(e => e.id === 'decision_2');
+
+      // when
+      const variables = variableResolver.getVariables(requiringDecision);
+
+      // then
+      expect(variables).to.have.length(1);
+      expect(variables[0]).to.have.property('name', 'decision');
+    }));
+
+
+    it('should provide input data as name', inject(function(variableResolver, elementRegistry) {
 
       // given
       const inputEntry = elementRegistry.get('inputEntry1').businessObject;
@@ -20,8 +34,24 @@ describe('CamundaVariableProvider', function() {
 
       // then
       expect(variables).to.have.length(1);
-      expect(variables[0]).to.have.property('name', 'InputData_status');
+      expect(variables[0]).to.have.property('name', 'status');
     }));
+
+
+    it('should provide BKM as name', inject(
+      function(variableResolver, _parent) {
+
+        // given
+        const requiringBkm = _parent.getDefinitions().get('drgElement').find(e => e.id === 'Bkm_1');
+
+        // when
+        const variables = variableResolver.getVariables(requiringBkm);
+
+        // then
+        expect(variables).to.have.length(1);
+        expect(variables[0]).to.have.property('name', 'Business Knowledge Model 2');
+      })
+    );
   });
 
 

--- a/test/fixtures/simple.dmn
+++ b/test/fixtures/simple.dmn
@@ -78,4 +78,37 @@
       </rule>
     </decisionTable>
   </decision>
+  <businessKnowledgeModel name="Business Knowledge Model 1" id="Bkm_1">
+    <encapsulatedLogic>
+      <formalParameter name="noType" />
+      <formalParameter name="string" typeRef="string" />
+      <formalParameter name="num" typeRef="number" />
+      <literalExpression>
+        <text>noType + num - string</text>
+      </literalExpression>
+    </encapsulatedLogic>
+    <knowledgeRequirement>
+      <requiredKnowledge href="#Bkm_2" />
+    </knowledgeRequirement>
+  </businessKnowledgeModel>
+  <businessKnowledgeModel name="Business Knowledge Model 2" id="Bkm_2">
+    <encapsulatedLogic>
+      <formalParameter name="noType" />
+      <formalParameter name="string" typeRef="string" />
+      <formalParameter name="num" typeRef="number" />
+      <literalExpression>
+        <text>noType + num - string</text>
+      </literalExpression>
+    </encapsulatedLogic>
+  </businessKnowledgeModel>
+  <decision id="decision_2" name="Approve order">
+    <informationRequirement>
+      <requiredDecision href="#decision" />
+    </informationRequirement>
+    <literalExpression>
+      <text>
+        Check Order.result = "ok"
+      </text>
+    </literalExpression>
+  </decision>
 </definitions>


### PR DESCRIPTION

<img width="880" alt="image" src="https://github.com/user-attachments/assets/725478d2-de21-46ed-8759-49619a3ad20e">
<img width="700" alt="image" src="https://github.com/user-attachments/assets/f06eb7ae-6de3-4f7c-b465-bdebb99f4c81">

Closes #117

### Proposed Changes

In the engine, we use BKM name as in the DMN specification and not ID. ID is still used for decisions. Input Data is not used in C8 so it does not need to be adjusted.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
