### PR TITLE
fix: display only a single version tag field in Camunda 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [camunda-dmn-js](https://github.com/camunda/camunda-dmn-j
 
 ___Note:__ Yet to be released changes appear here._
 
+### Key Changes in Properties Panel
+
+* `FIX`: display only a single version tag field in Camunda 7
+
 ## 3.1.0
 
 * `DEPS`: update to `diagram-js@15.2.4`

--- a/lib/base/Modeler.js
+++ b/lib/base/Modeler.js
@@ -17,8 +17,7 @@ import alignToOriginModule from '@bpmn-io/align-to-origin';
 
 import {
   DmnPropertiesPanelModule,
-  DmnPropertiesProviderModule,
-  ZeebePropertiesProviderModule
+  DmnPropertiesProviderModule
 } from 'dmn-js-properties-panel';
 
 import CamundaVariableProviderModule from './features/variable-provider';
@@ -52,8 +51,7 @@ export default class CamundaDmnModeler extends DmnModeler {
         disableAdjustOrigin ? diagramOriginModule : alignToOriginModule,
         disableGrid ? {} : gridModule,
         DmnPropertiesPanelModule,
-        DmnPropertiesProviderModule,
-        ZeebePropertiesProviderModule
+        DmnPropertiesProviderModule
       ]),
       literalExpression: mergeModules(literalExpression, [
         CamundaVariableProviderModule

--- a/lib/camunda-cloud/Modeler.js
+++ b/lib/camunda-cloud/Modeler.js
@@ -10,7 +10,10 @@
 
 import BaseModeler from '../base/Modeler';
 
-import { ZeebeTooltipProvider } from 'dmn-js-properties-panel';
+import {
+  ZeebePropertiesProviderModule,
+  ZeebeTooltipProvider
+} from 'dmn-js-properties-panel';
 
 import { commonModdleExtensions } from './util/commonModules';
 
@@ -18,6 +21,7 @@ export default class CamundaDmnModeler extends BaseModeler {
   constructor(options = {}) {
     const {
       common = {},
+      drd = {},
       moddleExtensions = {}
     } = options;
 
@@ -32,10 +36,28 @@ export default class CamundaDmnModeler extends BaseModeler {
           tooltip: ZeebeTooltipProvider
         }
       },
+      drd: mergeModules(drd, [
+        ZeebePropertiesProviderModule
+      ]),
       moddleExtensions: {
         ...commonModdleExtensions,
         ...moddleExtensions
       }
     });
   }
+}
+
+// helpers ///////////////////////
+
+function mergeModules(config, editorModules) {
+
+  const additionalModules = config.additionalModules || [];
+
+  return {
+    ...config,
+    additionalModules: [
+      ...editorModules,
+      ...additionalModules
+    ]
+  };
 }

--- a/test/base/ModelerSpec.js
+++ b/test/base/ModelerSpec.js
@@ -76,6 +76,37 @@ describe('BaseModeler', function() {
   });
 
 
+  it('should NOT inject platform-specific modules', async function() {
+
+    // when
+    const modeler = new Modeler({
+      container,
+      common: {
+        propertiesPanel: {
+          parent: propertiesContainer
+        },
+        overview: {
+          parent: overviewContainer
+        }
+      }
+    });
+
+    await modeler.importXML(diagramXML);
+
+    await modeler.open(modeler.getViews().find(({ type }) => type === 'drd'));
+
+    // assume
+    expect(modeler.getActiveView().type).to.eql('drd');
+
+    const viewer = modeler.getActiveViewer();
+
+    // then
+    expect(viewer.get('propertiesPanel')).to.exist;
+    expect(viewer.get('zeebePropertiesProvider', false)).not.to.exist;
+    expect(viewer.get('camundaPropertiesProvider', false)).not.to.exist;
+  });
+
+
   describe('additional modules', function() {
 
     it('should pass additional modules to boxed expression', async function() {

--- a/test/camunda-platform/ModelerSpec.js
+++ b/test/camunda-platform/ModelerSpec.js
@@ -78,6 +78,35 @@ describe('CamundaPlatformModeler', function() {
     });
 
 
+    it('should NOT inject Camunda 8 modules', async function() {
+
+      // when
+      const modeler = new Modeler({
+        container,
+        common: {
+          propertiesPanel: {
+            parent: propertiesContainer
+          },
+          overview: {
+            parent: overviewContainer
+          }
+        }
+      });
+
+      await modeler.importXML(diagramXML);
+
+      await modeler.open(modeler.getViews().find(({ type }) => type === 'drd'));
+
+      // assume
+      expect(modeler.getActiveView().type).to.eql('drd');
+
+      const viewer = modeler.getActiveViewer();
+
+      // then
+      expect(viewer.get('zeebePropertiesProvider', false)).not.to.exist;
+    });
+
+
     describe('additional modules', function() {
 
       it('should pass additional modules to boxed expression', async function() {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4844

### Proposed Changes

When implementing version tag for Camunda 8, we have added Zeebe properties provider to the base distribution. This caused version tag field to be displayed in Camunda 7 which inherits from the base.

![image](https://github.com/user-attachments/assets/cc8527f0-5029-4108-92a5-cb198e37cafd)
![image](https://github.com/user-attachments/assets/9f16fa86-e469-4938-923b-14553e3c719a)
![image](https://github.com/user-attachments/assets/3d38c5aa-472b-449b-83a3-0e44cecd6bc4)


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
